### PR TITLE
Allow for throwing function in closure

### DIFF
--- a/Sources/ExceptionCatcher/ExceptionCatcher.swift
+++ b/Sources/ExceptionCatcher/ExceptionCatcher.swift
@@ -26,11 +26,20 @@ public enum ExceptionCatcher {
 	```
 	*/
 	@discardableResult
-	public static func `catch`<T>(callback: () -> T) throws -> T {
+	public static func `catch`<T>(callback: () throws -> T) throws -> T {
 		var returnValue: T!
+		var returnError: Error?
 
 		try _ExceptionCatcher.catchException {
-			returnValue = callback()
+			do {
+				returnValue = try callback()
+			} catch {
+				returnError = error
+			}
+		}
+
+		if let error = returnError {
+			throw error
 		}
 
 		return returnValue


### PR DESCRIPTION
Hi, nice library!

I've added the possibility of passing a throwing function as the callback.
I don't think this impacts existing code, since you can still call it with a non-throwing function.
